### PR TITLE
Fixed test and some info

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+/.distignore            export-ignore
+/.editorconfig          export-ignore
+/.env                   export-ignore
+/.github/               export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/docs/                  export-ignore
+/mkdocs.yml             export-ignore
+/tests/                 export-ignore
+/vendor/                export-ignore
+composer.lock           export-ignore
+phpunit.xml             export-ignore
+README.md               export-ignore
+renovate.json           export-ignore
+test.php                export-ignore

--- a/tests/Feature/ZimbraTest.php
+++ b/tests/Feature/ZimbraTest.php
@@ -23,7 +23,8 @@ test(
 
         $parts = $message->getParts();
         expect($parts)->toHaveCount(1)
-            ->and($parts[0]->getContentType())->toContain('text/html');
+            ->and($parts[0]->getContentType())->toBe('text/html; charset=utf-8')
+            ->and($parts[0]->getContent())->toContain("this is a mail from zimbra");
     }
 );
 

--- a/tests/Fixtures/raw_email_from_zimbra.eml
+++ b/tests/Fixtures/raw_email_from_zimbra.eml
@@ -123,33 +123,6 @@ biente es cosa de todos.=20
 Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
-<html><body><div style=3D"font-family: arial, helvetica, sans-serif; font-s=
-ize: 12pt; color: #000000"><div>this is a mail from zimbra</div><div><br></=
-div><div data-marker=3D"__SIG_POST__">--</div><div><div style=3D""><font fa=
-ce=3D"helvetica"><span style=3D"font-size: 12px;">Jhon Smith</span></font><=
-/div><div style=3D"color:#202124;font-family:'arial' , 'helvetica' , sans-s=
-erif;font-size:small"><div><span style=3D"color:#000000;font-family:'helvet=
-ica'"><span style=3D"font-size:12px">Phone.: 666 555 444&nbsp;<br><br></spa=
-n></span><div><div><font color=3D"#000000" face=3D"helvetica"><span style=
-=3D"font-size:12px">Este email es confidencial y previsto solamente para el=
- uso de la persona a quien&nbsp;</span></font><span style=3D"font-size:12px=
-;color:rgb( 0 , 0 , 0 );font-family:'helvetica'">se dirige. Si usted no es =
-el destinatario previsto, esto es debido a un error, por lo&nbsp;</span><sp=
-an style=3D"font-size:12px;color:rgb( 0 , 0 , 0 );font-family:'helvetica'">=
-que cualquier uso, difusi=C3=B3n, expedici=C3=B3n, impresi=C3=B3n, o copiad=
-o de este email est=C3=A1&nbsp;</span><span style=3D"font-size:12px;color:r=
-gb( 0 , 0 , 0 );font-family:'helvetica'">prohibido conforme al C=C3=B3digo =
-Penal. Si usted ha recibido este email por error, por&nbsp;</span><span sty=
-le=3D"font-size:12px;color:rgb( 0 , 0 , 0 );font-family:'helvetica'">favor =
-notif=C3=ADquelo a la direcci=C3=B3n </span><a href=3D"mailto:esercol@gobie=
-rnodecanarias.org" style=3D"font-size:12px;font-family:'helvetica'" rel=3D"=
-nofollow noopener noreferrer nofollow noopener noreferrer" target=3D"_blank=
-">test2@example.com</a><span style=3D"font-size:12px;color:rgb=
-( 0 , 0 , 0 );font-family:'helvetica'">.</span></div><div><font color=3D"#0=
-00000" face=3D"helvetica"><span style=3D"font-size:12px">Antes de imprimir =
-este email, piense si es realmente necesario: el Medio Ambiente&nbsp;</span=
-></font><span style=3D"font-size:12px;color:rgb( 0 , 0 , 0 );font-family:'h=
-elvetica'">es cosa de todos.</span></div></div></div></div><div id=3D"gtx-t=
-rans"><div class=3D"gtx-trans-icon"></div></div></div></div></body></html>
+<html><body><div>this is a mail from zimbra</div></body></html>
 --=_8ed808b7-e49d-4b98-81b1-3e62febadf08--
 


### PR DESCRIPTION
This pull request includes several updates and improvements to the `MimeMailParser` class and related test files. The changes focus on enhancing the handling of email parsing, specifically for multipart messages and different content transfer encodings.

### Enhancements to `MimeMailParser`:

* Improved handling of continued headers and body headers in the `parse` method, ensuring proper parsing of multiline headers and multipart boundaries. [[1]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6R306-L336) [[2]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6R346-L370) [[3]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6L386-R411) [[4]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6L402-R429)
* Added support for decoding `quoted-printable` content transfer encoding in the `getContent` method.

### Test updates:

* Updated `tests/Feature/ZimbraTest.php` to assert the correct content type and content of the email parts.
* Simplified the raw email content in `tests/Fixtures/raw_email_from_zimbra.eml` to focus on essential elements for testing.

### Configuration updates:

* Added several files and directories to the `.gitattributes` file to be ignored during export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email parsing logic for better handling of multipart messages and content encoding.
  
- **Bug Fixes**
	- Improved handling of continued headers and multipart boundaries, ensuring accurate parsing.

- **Tests**
	- Updated test cases to enhance validation of parsed email content and types.

- **Chores**
	- Simplified HTML content in test email fixture for clarity and conciseness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->