### PR TITLE
Fix email parsin

### DIFF
--- a/src/MessagePart.php
+++ b/src/MessagePart.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * MessagePart.php
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Erseco;
+
+/**
+ * MessagePart class for handling individual parts of an email message
+ *
+ * This class represents a single part of an email message, which could be
+ * the body text, HTML content, or an attachment.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+class MessagePart implements \JsonSerializable
+{
+    protected string $content;
+
+    protected array $headers;
+
+    /**
+     * Create a new MessagePart instance
+     *
+     * @param string $content The content of the message part
+     * @param array  $headers The headers associated with this part
+     */
+    public function __construct(string $content, array $headers = [])
+    {
+        $this->content = $content;
+        $this->headers = $headers;
+    }
+
+    /**
+     * Get the content type of this message part
+     *
+     * @return string The content type or empty string if not set
+     */
+    public function getContentType(): string
+    {
+        return $this->headers['Content-Type'] ?? '';
+    }
+
+    /**
+     * Get all headers for this message part
+     *
+     * @return array Array of headers
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Get a specific header value
+     *
+     * @param string $name    The name of the header to retrieve
+     * @param mixed  $default Default value if header not found
+     *
+     * @return mixed The header value or default if not found
+     */
+    public function getHeader(string $name, $default = null): mixed
+    {
+        return $this->headers[$name] ?? $default;
+    }
+
+    /**
+     * Get the decoded content of this message part
+     *
+     * @return string The decoded content
+     */
+    public function getContent(): string
+    {
+        $content = $this->content;
+        $encoding = strtolower($this->getHeader('Content-Transfer-Encoding', ''));
+
+        if ($encoding === 'base64') {
+            return base64_decode($content);
+        } elseif ($encoding === 'quoted-printable') {
+            return quoted_printable_decode($content);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Check if this part is HTML content
+     *
+     * @return bool True if content type is text/html
+     */
+    public function isHtml(): bool
+    {
+        return str_starts_with(strtolower($this->getContentType()), 'text/html');
+    }
+
+    /**
+     * Check if this part is plain text content
+     *
+     * @return bool True if content type is text/plain
+     */
+    public function isText(): bool
+    {
+        return str_starts_with(strtolower($this->getContentType()), 'text/plain');
+    }
+
+    /**
+     * Check if this part is an image
+     *
+     * @return bool True if content type starts with image/
+     */
+    public function isImage(): bool
+    {
+        return str_starts_with(strtolower($this->getContentType()), 'image/');
+    }
+
+    /**
+     * Check if this part is an attachment
+     *
+     * @return bool True if content disposition is attachment
+     */
+    public function isAttachment(): bool
+    {
+        return str_starts_with($this->getHeader('Content-Disposition', ''), 'attachment');
+    }
+
+    /**
+     * Get the filename of this part if it's an attachment
+     *
+     * @return string The filename or empty string if not found
+     */
+    public function getFilename(): string
+    {
+        if (preg_match('/filename=([^;]+)/', $this->getHeader('Content-Disposition'), $matches)) {
+            return trim($matches[1], '"');
+        }
+
+        if (preg_match('/name=([^;]+)/', $this->getContentType(), $matches)) {
+            return trim($matches[1], '"');
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the size of the content in bytes
+     *
+     * @return int Size in bytes
+     */
+    public function getSize(): int
+    {
+        return strlen($this->getContent());
+    }
+
+    /**
+     * Convert the message part to an array representation
+     *
+     * @return array Array containing message part data including headers, content, filename, and size
+     */
+    public function toArray(): array
+    {
+        return [
+            'headers' => $this->getHeaders(),
+            'content' => $this->getContent(),
+            'filename' => $this->getFilename(),
+            'size' => $this->getSize(),
+        ];
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     *
+     * @return array Array containing message part data
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/src/MimeMailParser.php
+++ b/src/MimeMailParser.php
@@ -12,6 +12,8 @@
 
 namespace Erseco;
 
+require_once __DIR__ . '/MessagePart.php';
+
 /**
  * MimeMailParser class for parsing email messages
  *
@@ -233,7 +235,7 @@ class Message implements \JsonSerializable
 
     /**
      *  Get the attachments of a message
-     * 
+     *
      * @return MessagePart[]
      */
     public function getAttachments(): array
@@ -310,7 +312,7 @@ class Message implements \JsonSerializable
                     $this->headers[$headerInProgress] = '';
                 }
                 $this->headers[$headerInProgress] .= PHP_EOL . $line;
-           
+
                 $headerInProgress = str_ends_with($this->headers[$headerInProgress], ';');
                 continue;
             }
@@ -323,15 +325,15 @@ class Message implements \JsonSerializable
             }
 
             // Check for multipart boundary end
-            if (isset($this->boundary) && str_ends_with($line, '--'.$this->boundary.'--')) {
-                $line = str_replace('--'.$this->boundary.'--', '', $line);
+            if (isset($this->boundary) && str_ends_with($line, '--' . $this->boundary . '--')) {
+                $line = str_replace('--' . $this->boundary . '--', '', $line);
                 $currentBody .= $line;
                 break;
             }
 
             // Check for multipart boundary
-            if (isset($this->boundary) && str_ends_with($line, '--'.$this->boundary)) {
-                $line = str_replace('--'.$this->boundary, '', $line);
+            if (isset($this->boundary) && str_ends_with($line, '--' . $this->boundary)) {
+                $line = str_replace('--' . $this->boundary, '', $line);
 
                 // Add the previous part before starting a new one
                 if ($collectingBody) {
@@ -362,8 +364,8 @@ class Message implements \JsonSerializable
                 $bodyContentStarted = true;
 
                 // Special handling for boundary close line
-                if (isset($this->boundary) && str_contains($line, '--'.$this->boundary)) {
-                    $parts = explode('--'.$this->boundary, $line);
+                if (isset($this->boundary) && str_contains($line, '--' . $this->boundary)) {
+                    $parts = explode('--' . $this->boundary, $line);
                     $currentBody .= $parts[0];
 
                     // Add part and prepare for next
@@ -381,7 +383,7 @@ class Message implements \JsonSerializable
 
             // Detect multipart content type with boundary
             if (preg_match("/^Content-Type: (?<contenttype>multipart\/.*); boundary=(?<boundary>.*)$/", $line, $matches)) {
-                $this->headers['Content-Type'] = $matches['contenttype']."; boundary=".$matches['boundary'];
+                $this->headers['Content-Type'] = $matches['contenttype'] . "; boundary=" . $matches['boundary'];
                 $this->boundary = trim($matches['boundary'], '"');
                 continue;
             }
@@ -465,181 +467,5 @@ class Message implements \JsonSerializable
             }
         }
         $this->parts[] = new MessagePart(trim($currentBody), $currentBodyHeaders);
-    }
-}
-
-/**
- * MessagePart class for handling individual parts of an email message
- *
- * This class represents a single part of an email message, which could be
- * the body text, HTML content, or an attachment.
- *
- * @category Library
- * @package  MimeMailParser
- * @author   Ernesto Serrano <info@ernesto.es>
- * @license  MIT https://opensource.org/licenses/MIT
- * @link     https://github.com/erseco/mime-mail-parser
- */
-class MessagePart implements \JsonSerializable
-{
-    protected string $content;
-
-    protected array $headers;
-
-    /**
-     * Create a new MessagePart instance
-     *
-     * @param string $content The content of the message part
-     * @param array  $headers The headers associated with this part
-     */
-    public function __construct(string $content, array $headers = [])
-    {
-        $this->content = $content;
-        $this->headers = $headers;
-    }
-
-    /**
-     * Get the content type of this message part
-     *
-     * @return string The content type or empty string if not set
-     */
-    public function getContentType(): string
-    {
-        return $this->headers['Content-Type'] ?? '';
-    }
-
-    /**
-     * Get all headers for this message part
-     *
-     * @return array Array of headers
-     */
-    public function getHeaders(): array
-    {
-        return $this->headers;
-    }
-
-    /**
-     * Get a specific header value
-     *
-     * @param string $name    The name of the header to retrieve
-     * @param mixed  $default Default value if header not found
-     *
-     * @return mixed The header value or default if not found
-     */
-    public function getHeader(string $name, $default = null): mixed
-    {
-        return $this->headers[$name] ?? $default;
-    }
-
-    /**
-     * Get the decoded content of this message part
-     *
-     * @return string The decoded content
-     */
-    public function getContent(): string
-    {
-        $content = $this->content;
-        $encoding = strtolower($this->getHeader('Content-Transfer-Encoding', ''));
-
-        if ($encoding === 'base64') {
-            return base64_decode($content);
-        } elseif ($encoding === 'quoted-printable') {
-            return quoted_printable_decode($content);
-        }
-
-        return $content;
-    }
-
-    /**
-     * Check if this part is HTML content
-     *
-     * @return bool True if content type is text/html
-     */
-    public function isHtml(): bool
-    {
-        return str_starts_with(strtolower($this->getContentType()), 'text/html');
-    }
-
-    /**
-     * Check if this part is plain text content
-     *
-     * @return bool True if content type is text/plain
-     */
-    public function isText(): bool
-    {
-        return str_starts_with(strtolower($this->getContentType()), 'text/plain');
-    }
-
-    /**
-     * Check if this part is an image
-     *
-     * @return bool True if content type starts with image/
-     */
-    public function isImage(): bool
-    {
-        return str_starts_with(strtolower($this->getContentType()), 'image/');
-    }
-
-    /**
-     * Check if this part is an attachment
-     *
-     * @return bool True if content disposition is attachment
-     */
-    public function isAttachment(): bool
-    {
-        return str_starts_with($this->getHeader('Content-Disposition', ''), 'attachment');
-    }
-
-    /**
-     * Get the filename of this part if it's an attachment
-     *
-     * @return string The filename or empty string if not found
-     */
-    public function getFilename(): string
-    {
-        if (preg_match('/filename=([^;]+)/', $this->getHeader('Content-Disposition'), $matches)) {
-            return trim($matches[1], '"');
-        }
-
-        if (preg_match('/name=([^;]+)/', $this->getContentType(), $matches)) {
-            return trim($matches[1], '"');
-        }
-
-        return '';
-    }
-
-    /**
-     * Get the size of the content in bytes
-     *
-     * @return int Size in bytes
-     */
-    public function getSize(): int
-    {
-        return strlen($this->getContent());
-    }
-
-    /**
-     * Convert the message part to an array representation
-     *
-     * @return array Array containing message part data including headers, content, filename, and size
-     */
-    public function toArray(): array
-    {
-        return [
-            'headers' => $this->getHeaders(),
-            'content' => $this->getContent(),
-            'filename' => $this->getFilename(),
-            'size' => $this->getSize(),
-        ];
-    }
-
-    /**
-     * Specify data which should be serialized to JSON
-     *
-     * @return array Array containing message part data
-     */
-    public function jsonSerialize(): mixed
-    {
-        return $this->toArray();
     }
 }

--- a/src/MimeMailParser.php
+++ b/src/MimeMailParser.php
@@ -296,6 +296,7 @@ class Message implements \JsonSerializable
         $headerInProgress = null;
 
         $collectingBody = false;
+        $bodyContentStarted = false;
         $currentBody = '';
         $currentBodyHeaders = [];
         $currentBodyHeaderInProgress = null;
@@ -338,13 +339,14 @@ class Message implements \JsonSerializable
                 }
 
                 $collectingBody = true;
+                $bodyContentStarted = false;
                 $currentBody = '';
                 $currentBodyHeaders = [];
                 continue;
             }
 
-            // Collect body headers
-            if ($collectingBody && preg_match('/^(?<key>[A-Za-z\-0-9]+): (?<value>.*)$/', $line, $matches)) {
+            // Collect body headers (only before body content starts)
+            if ($collectingBody && !$bodyContentStarted && preg_match('/^(?<key>[A-Za-z\-0-9]+): (?<value>.*)$/', $line, $matches)) {
                 $currentBodyHeaders[$matches['key']] = $matches['value'];
 
                 // Check for continued headers
@@ -357,19 +359,22 @@ class Message implements \JsonSerializable
 
             // Collect body content
             if ($collectingBody) {
+                $bodyContentStarted = true;
+
                 // Special handling for boundary close line
                 if (isset($this->boundary) && str_contains($line, '--'.$this->boundary)) {
                     $parts = explode('--'.$this->boundary, $line);
                     $currentBody .= $parts[0];
-                
+
                     // Add part and prepare for next
                     $this->addPart($currentBody, $currentBodyHeaders);
                     $currentBody = '';
                     $currentBodyHeaders = [];
+                    $bodyContentStarted = false;
                     $collectingBody = true;
                     continue;
                 }
-            
+
                 $currentBody .= $line . PHP_EOL;
                 continue;
             }
@@ -384,7 +389,7 @@ class Message implements \JsonSerializable
             // Collect message headers
             if (preg_match('/^(?<key>[A-Za-z\-0-9]+): (?<value>.*)$/', $line, $matches)) {
                 // Special handling for single-part messages or non-multipart content types
-                if (strtolower($matches['key']) === 'content-type' && !isset($this->boundary) && !str_contains($matches['value'], 'multipart/mixed')) {
+                if (strtolower($matches['key']) === 'content-type' && !isset($this->boundary) && !str_contains($matches['value'], 'multipart/')) {
                     $collectingBody = true;
                     $currentBody = '';
                     $currentBodyHeaders = [
@@ -412,6 +417,7 @@ class Message implements \JsonSerializable
             if (preg_match("~^--(?<boundary>[0-9A-Za-z'()+_,-./:=?]{0,68}[0-9A-Za-z'()+_,-./=?])~", $line, $matches)) {
                 $this->boundary = trim($matches['boundary']);
                 $collectingBody = true;
+                $bodyContentStarted = false;
                 $currentBody = '';
                 $currentBodyHeaders = [];
                 continue;
@@ -447,6 +453,17 @@ class Message implements \JsonSerializable
      */
     protected function addPart(string $currentBody, array $currentBodyHeaders): void
     {
+        $contentType = $currentBodyHeaders['Content-Type'] ?? '';
+        if (str_contains(strtolower($contentType), 'multipart/')) {
+            if (preg_match('/boundary=["\']?([^"\';\s]+)/i', $contentType, $matches)) {
+                $innerMessage = "Content-Type: " . $contentType . "\n\n" . $currentBody;
+                $innerParser = new self($innerMessage);
+                foreach ($innerParser->getParts() as $innerPart) {
+                    $this->parts[] = $innerPart;
+                }
+                return;
+            }
+        }
         $this->parts[] = new MessagePart(trim($currentBody), $currentBodyHeaders);
     }
 }

--- a/tests/Feature/GmailTest.php
+++ b/tests/Feature/GmailTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Gmail tests for MimeMailParser class
  *
@@ -8,12 +9,14 @@
  * @license  MIT https://opensource.org/licenses/MIT
  * @link     https://github.com/erseco/mime-mail-parser
  */
+
 namespace Tests\Feature;
 
 use Erseco\Message;
 
 test(
-    'can parse a simple gmail message', function () {
+    'can parse a simple gmail message',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_gmail.eml');
 
         expect($message->getFrom())->toBe('Test User 1 <test1@example.com>')
@@ -33,7 +36,8 @@ test(
 );
 
 test(
-    'can parse a gmail message with attachments', function () {
+    'can parse a gmail message with attachments',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_gmail_attachments.eml');
 
         expect($message->getFrom())->toBe('Test User 1 <test1@example.com>')
@@ -56,7 +60,8 @@ test(
 );
 
 test(
-    'can parse a gmail message with GB encoding', function () {
+    'can parse a gmail message with GB encoding',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_gmail_gb.eml');
 
         expect($message->getFrom())->toBe('Test User 2 <test2@example.com>')

--- a/tests/Feature/GmailTest.php
+++ b/tests/Feature/GmailTest.php
@@ -42,7 +42,11 @@ test(
         ->and($message->getDate()?->format('Y-m-d H:i:s'))->toBe('2024-12-04 15:47:13');
 
         $parts = $message->getParts();
-        expect($parts)->toHaveCount(2);
+        expect($parts)->toHaveCount(4)
+            ->and($parts[0]->getContentType())->toContain('text/plain')
+            ->and($parts[1]->getContentType())->toContain('text/html')
+            ->and($parts[2]->getContentType())->toContain('image/jpeg')
+            ->and($parts[3]->getContentType())->toContain('application/pdf');
 
         $attachments = $message->getAttachments();
         expect($attachments)->toHaveCount(1)

--- a/tests/Feature/NextcloudTest.php
+++ b/tests/Feature/NextcloudTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Nextcloud Mail tests for MimeMailParser class
  *
@@ -8,12 +9,14 @@
  * @license  MIT https://opensource.org/licenses/MIT
  * @link     https://github.com/erseco/mime-mail-parser
  */
+
 namespace Tests\Feature;
 
 use Erseco\Message;
 
 test(
-    'can parse a nextcloud message', function () {
+    'can parse a nextcloud message',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_nextcloud.eml');
 
         expect($message->getFrom())->toBe('Test User 3 <test3@example.com>')
@@ -28,7 +31,8 @@ test(
 );
 
 test(
-    'can parse a nextcloud message with attachments', function () {
+    'can parse a nextcloud message with attachments',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_nextcloud_attachments.eml');
 
         expect($message->getFrom())->toBe('Test User 3 <test3@example.com>')

--- a/tests/Feature/ZimbraTest.php
+++ b/tests/Feature/ZimbraTest.php
@@ -19,12 +19,14 @@ test(
         expect($message->getFrom())->toBe('Test User 2 <test2@example.com>')
         ->and($message->getTo())->toBe('taskwp <receiver@example.com>')
         ->and($message->getSubject())->toBe('test from zimbra')
-        ->and($message->getContentType())->toBe('text/html; charset=utf-8');
+        ->and($message->getContentType())->toContain('multipart/alternative');
 
         $parts = $message->getParts();
-        expect($parts)->toHaveCount(1)
-            ->and($parts[0]->getContentType())->toBe('text/html; charset=utf-8')
-            ->and($parts[0]->getContent())->toContain("this is a mail from zimbra");
+        expect($parts)->toHaveCount(2)
+            ->and($parts[0]->getContentType())->toBe('text/plain; charset=utf-8')
+            ->and($parts[0]->getContent())->toContain('this is a mail from zimbra')
+            ->and($parts[1]->getContentType())->toBe('text/html; charset=utf-8')
+            ->and($parts[1]->getContent())->toContain('this is a mail from zimbra');
     }
 );
 
@@ -52,7 +54,9 @@ test(
         ->and($message->getSubject())->toBe('test from zimbra with embedded image');
 
         $parts = $message->getParts();
-        expect($parts)->toHaveCount(1)
-            ->and($parts[0]->getContentType())->toContain('image/jpeg');
+        expect($parts)->toHaveCount(3)
+            ->and($parts[0]->getContentType())->toContain('text/plain')
+            ->and($parts[1]->getContentType())->toContain('text/html')
+            ->and($parts[2]->getContentType())->toContain('image/jpeg');
     }
 );

--- a/tests/Feature/ZimbraTest.php
+++ b/tests/Feature/ZimbraTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Zimbra tests for MimeMailParser class
  *
@@ -8,12 +9,14 @@
  * @license  MIT https://opensource.org/licenses/MIT
  * @link     https://github.com/erseco/mime-mail-parser
  */
+
 namespace Tests\Feature;
 
 use Erseco\Message;
 
 test(
-    'can parse a zimbra message', function () {
+    'can parse a zimbra message',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_zimbra.eml');
 
         expect($message->getFrom())->toBe('Test User 2 <test2@example.com>')
@@ -31,7 +34,8 @@ test(
 );
 
 test(
-    'can parse a zimbra message with attachments', function () {
+    'can parse a zimbra message with attachments',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_zimbra_attachments.eml');
 
         expect($message->getFrom())->toBe('Test User 2 <test2@example.com>')
@@ -46,7 +50,8 @@ test(
 );
 
 test(
-    'can parse a zimbra message with embedded content', function () {
+    'can parse a zimbra message with embedded content',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/raw_email_from_zimbra_embedded.eml');
 
         expect($message->getFrom())->toBe('Test User 2 <test2@example.com>')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -35,7 +35,8 @@
 */
 
 expect()->extend(
-    'toBeOne', function () {
+    'toBeOne',
+    function () {
         return $this->toBe(1);
     }
 );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,5 +26,4 @@ use Erseco\MimeMailParser;
  */
 abstract class TestCase extends BaseTestCase
 {
-
 }

--- a/tests/Unit/MimeMailParserTest.php
+++ b/tests/Unit/MimeMailParserTest.php
@@ -14,13 +14,11 @@ namespace Erseco\Message\Tests\Unit;
 
 require_once __DIR__ . '/../../src/MimeMailParser.php';
 
-
 use Erseco\Message;
 
-
-
 it(
-    'can parse a simple mail message', function () {
+    'can parse a simple mail message',
+    function () {
         $messageString = <<<EOF
 From: Sender <no-reply@example.com>
 To: Receiver <receiver@example.com>
@@ -53,7 +51,8 @@ EOF;
 );
 
 it(
-    'can parse lowercase headers', function () {
+    'can parse lowercase headers',
+    function () {
         $messageString = <<<EOF
 from: Sender <no-reply@example.com>
 to: Receiver <receiver@example.com>
@@ -86,7 +85,8 @@ EOF;
 );
 
 it(
-    'can parse a mail message with boundaries', function () {
+    'can parse a mail message with boundaries',
+    function () {
         date_default_timezone_set('UTC');
         $messageString = <<<EOF
 From: sender@example.com
@@ -156,12 +156,12 @@ EOF;
 </html>
 EOF
             );
-
     }
 );
 
 it(
-    'can parse a complex mail message', function () {
+    'can parse a complex mail message',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/complex_email.eml');
 
         expect($message->getFrom())->toBe('Service <no-reply@example.com>')
@@ -195,7 +195,8 @@ it(
 );
 
 it(
-    'can parse a multi-format mail message', function () {
+    'can parse a multi-format mail message',
+    function () {
         $message = Message::fromFile(__DIR__ . '/../Fixtures/multiformat_email.eml');
 
         expect($message->getFrom())->toBe('Service <no-reply@example.com>')
@@ -228,12 +229,12 @@ Hi John,
 This is a confirmation of your appointment.
 EOF
             );
-
     }
 );
 
 it(
-    'can get contents of an encoded part', function () {
+    'can get contents of an encoded part',
+    function () {
         $messageString = <<<EOF
 From: sender@example.com
 To: recipient@example.com
@@ -288,7 +289,8 @@ EOF;
 );
 
 it(
-    'skips initial content that is not part of the message', function () {
+    'skips initial content that is not part of the message',
+    function () {
         $messageString = <<<EOF
 This is some initial content that is not part of the message.
 
@@ -333,7 +335,8 @@ EOF
 );
 
 it(
-    'catches boundaries on the same line', function () {
+    'catches boundaries on the same line',
+    function () {
         $messageString = <<<EOF
 From: sender@example.com
 To: recipient@example.com
@@ -381,7 +384,8 @@ EOF
 );
 
 it(
-    'still parses with a broken boundary', function () {
+    'still parses with a broken boundary',
+    function () {
         $messageString = <<<EOF
 From: sender@example.com
 To: recipient@example.com
@@ -419,10 +423,9 @@ EOF;
     }
 );
 
-
 it(
-    'can parse a multi-format mail message from file with attachment', function () {
-
+    'can parse a multi-format mail message from file with attachment',
+    function () {
         $rawEmail = file_get_contents(__DIR__ . '/../Fixtures/attachment_email.eml');
         $message = new Message($rawEmail);
 
@@ -455,14 +458,12 @@ it(
 test
 EOF
             );
-
     }
 );
 
-
 it(
-    'can parse a multi-format mail message from file with multiple attachments', function () {
-
+    'can parse a multi-format mail message from file with multiple attachments',
+    function () {
         $rawEmail = file_get_contents(__DIR__ . '/../Fixtures/multi_attachment_email.eml');
         $message = new Message($rawEmail);
 
@@ -494,8 +495,5 @@ it(
                 'Content-Transfer-Encoding' => 'base64',
                 ]
             )->and($message->getTextPart()?->getContent())->toContain('Dear Team');
-
     }
 );
-
-

--- a/tests/Unit/MimeMailParserTest.php
+++ b/tests/Unit/MimeMailParserTest.php
@@ -474,25 +474,26 @@ it(
 
         $parts = $message->getParts();
 
-        expect($parts)->toHaveCount(3)
-            ->and($parts[0]->getContentType())->toBe('image/jpeg; name=embedded_image_0')
-            ->and($parts[0]->getHeaders())->toBe(
+        expect($parts)->toHaveCount(5)
+            ->and($parts[0]->getContentType())->toBe('text/plain; charset=utf-8')
+            ->and($parts[1]->getContentType())->toBe('text/html; charset=utf-8')
+            ->and($parts[2]->getContentType())->toBe('image/jpeg; name=embedded_image_0')
+            ->and($parts[2]->getHeaders())->toBe(
                 [
                 'Content-Type' => 'image/jpeg; name=embedded_image_0',
-                'Content-Transfer-Encoding' => 'base64',
-                'Content-Description' => 'HTML Version of Message',
                 'Content-Disposition' => 'inline; filename=embedded_image_0',
+                'Content-Transfer-Encoding' => 'base64',
                 'Content-ID' => '<XUO5zeHECaACtEYl74_9oDC@tfvs0015>',
                 ]
             )
-            ->and($parts[1]->getContentType())->toBe('application/pdf; name=sample-1-small.pdf')
-            ->and($parts[1]->getHeaders())->toBe(
+            ->and($parts[3]->getContentType())->toBe('application/pdf; name=sample-1-small.pdf')
+            ->and($parts[3]->getHeaders())->toBe(
                 [
                 'Content-Type' => 'application/pdf; name=sample-1-small.pdf',
                 'Content-Disposition' => 'attachment; filename=sample-1-small.pdf',
                 'Content-Transfer-Encoding' => 'base64',
                 ]
-            )->and($message->getTextPart()?->getContent())->toBe(null);
+            )->and($message->getTextPart()?->getContent())->toContain('Dear Team');
 
     }
 );


### PR DESCRIPTION
This pull request significantly improves the parsing of multipart MIME email messages in the `MimeMailParser` class. The main enhancement is the ability to recursively parse nested multipart messages, ensuring that all individual parts (such as text, HTML, images, and attachments) are correctly extracted and represented. The associated tests have been updated to verify the improved handling and correct part counts for various real-world email formats.

### MIME parsing improvements

* Added recursive parsing for multipart messages in the `addPart` method, enabling extraction of all inner parts from nested multipart content types. (`src/MimeMailParser.php`)
* Updated parsing logic to accurately distinguish between body headers and body content, using a new `$bodyContentStarted` flag to prevent headers from being misclassified after body content begins. (`src/MimeMailParser.php`) [[1]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6R299) [[2]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6R342-R349) [[3]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6R362-R363) [[4]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6R373) [[5]](diffhunk://#diff-ef0b042a32e081e21cf41540885da46241a0cdc0a9d748a91ef378b786b3aca6R420)
* Improved detection of multipart messages by matching any `multipart/` content type, not just `multipart/mixed`. (`src/MimeMailParser.php`)

### Test updates

* Updated `GmailTest`, `ZimbraTest`, and `MimeMailParserTest` to expect and validate the correct number and types of parts after parsing multipart messages, reflecting the improved extraction logic. (`tests/Feature/GmailTest.php`, `tests/Feature/ZimbraTest.php`, `tests/Unit/MimeMailParserTest.php`) [[1]](diffhunk://#diff-ada96773176836f0e438ed0a7c286431b3476dc5fa77ab95d65e777aef0f27efL45-R49) [[2]](diffhunk://#diff-c9bf000dcd745b8672e77de58ce467e6d7338a3f497d43a9625b79ed0ce6135fL22-R29) [[3]](diffhunk://#diff-c9bf000dcd745b8672e77de58ce467e6d7338a3f497d43a9625b79ed0ce6135fL55-R60) [[4]](diffhunk://#diff-cfbaf33f55a40fcb685bf651de8a57f3bdbdd3fc39f7d042a2fd763d9de961ebL477-R496)