### PR TITLE
Add more php versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2, 8.1, 8.0]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1, 8.0]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}


### PR DESCRIPTION
This pull request updates the PHP version matrix in the GitHub Actions test workflow to include the latest PHP releases. This ensures our tests run against all currently supported PHP versions.

Testing matrix update:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL12-R12): Added PHP 8.5 and 8.4 to the test matrix, so CI now runs on PHP versions 8.0 through 8.5.