### PR TITLE
Add RFC 2047 encoded header decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,23 @@ $message = Message::fromString($rawEmail);
 $message = Message::fromFile('/path/to/email.eml');
 
 $message->getHeaders();                 // get all headers as array
-$message->getHeader('Content-Type');    // get specific header
+$message->getHeader('Content-Type');    // get specific header (raw unfolded value)
 $message->getContentType();             // 'multipart/mixed; boundary="----=_Part_1_1234567890"'
 $message->getFrom();                    // 'Service <service@example.com>'
 $message->getTo();                      // 'John Doe <johndoe@example.com>'
-$message->getSubject();                 // 'Subject line'
+$message->getSubject();                 // raw subject (may still contain RFC 2047 encoded words)
 $message->getDate();                    // DateTime object when the email was sent
+
+// RFC 2047: raw vs decoded headers
+// getHeader() / getSubject() keep the raw unfolded value, including encoded-words.
+// getDecodedHeader() and the convenience helpers decode B/Q encoded-words to text.
+$message->getHeader('Subject');         // '=?UTF-8?B?UmV1bmnDs24gZGUgcHJveWVjdG8=?='
+$message->getDecodedHeader('Subject');  // 'Reunión de proyecto'
+$message->getDecodedSubject();          // same as getDecodedHeader('Subject')
+$message->getDecodedFrom();
+$message->getDecodedTo();
+$message->getDecodedReplyTo();
+
 
 $message->getParts();       // Returns array of MessagePart objects
 $message->getHtmlPart();    // Returns MessagePart with HTML content

--- a/src/Message.php
+++ b/src/Message.php
@@ -202,6 +202,68 @@ class Message implements \JsonSerializable
     }
 
     /**
+     * Get a header value with RFC 2047 encoded words decoded.
+     *
+     * Unlike getHeader(), this returns human-readable text (preferably UTF-8).
+     * The raw unfolded value remains available via getHeader().
+     *
+     * @param string $header  The name of the header to retrieve.
+     * @param mixed  $default Default value if the header is not found.
+     *
+     * @return mixed Decoded header value or the supplied default.
+     */
+    public function getDecodedHeader(string $header, $default = null): mixed
+    {
+        $value = $this->getHeader($header, $default);
+
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        return Rfc2047::decode($value);
+    }
+
+    /**
+     * Get the subject with RFC 2047 decoding applied.
+     *
+     * @return string Decoded subject.
+     */
+    public function getDecodedSubject(): string
+    {
+        return $this->getDecodedHeader('Subject', '');
+    }
+
+    /**
+     * Get the From header with RFC 2047 decoding applied.
+     *
+     * @return string Decoded From header.
+     */
+    public function getDecodedFrom(): string
+    {
+        return $this->getDecodedHeader('From', '');
+    }
+
+    /**
+     * Get the To header with RFC 2047 decoding applied.
+     *
+     * @return string Decoded To header.
+     */
+    public function getDecodedTo(): string
+    {
+        return $this->getDecodedHeader('To', '');
+    }
+
+    /**
+     * Get the Reply-To header with RFC 2047 decoding applied.
+     *
+     * @return string Decoded Reply-To header.
+     */
+    public function getDecodedReplyTo(): string
+    {
+        return $this->getDecodedHeader('Reply-To', '');
+    }
+
+    /**
      * Get the message date.
      *
      * @return \DateTime|null Parsed date or null.

--- a/src/Rfc2047.php
+++ b/src/Rfc2047.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * RFC 2047 encoded-word decoder for MIME headers.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Erseco;
+
+/**
+ * Decode RFC 2047 encoded words without requiring mbstring or iconv.
+ *
+ * When charset conversion is unavailable or fails, the decoder returns the
+ * safest available value (original token or decoded bytes) without throwing.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+final class Rfc2047
+{
+    /**
+     * Decode all RFC 2047 encoded words in a header value.
+     *
+     * Adjacent encoded words separated only by linear whitespace are joined
+     * without that whitespace, per RFC 2047.
+     *
+     * @param string $value Unfolded header value.
+     *
+     * @return string Decoded header value, preferably UTF-8.
+     */
+    public static function decode(string $value): string
+    {
+        $pattern = '/((?:=\?[^?\s]+\?[BbQq]\?[^?]*\?=)'
+            . '(?:[ \t]+(?:=\?[^?\s]+\?[BbQq]\?[^?]*\?=))*)/';
+
+        $decoded = preg_replace_callback(
+            $pattern,
+            static function (array $matches): string {
+                preg_match_all(
+                    '/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/',
+                    $matches[1],
+                    $words,
+                    PREG_SET_ORDER
+                );
+
+                $result = '';
+
+                foreach ($words as $word) {
+                    $result .= self::decodeWord($word[0], $word[1], $word[2], $word[3]);
+                }
+
+                return $result;
+            },
+            $value
+        );
+
+        return $decoded ?? $value;
+    }
+
+    /**
+     * Decode a single encoded-word token.
+     *
+     * @param string $original Original encoded-word text.
+     * @param string $charset  Charset name.
+     * @param string $encoding B or Q (any case).
+     * @param string $text     Encoded payload.
+     *
+     * @return string Decoded text or the original token on failure.
+     */
+    private static function decodeWord(
+        string $original,
+        string $charset,
+        string $encoding,
+        string $text
+    ): string {
+        $encoding = strtoupper($encoding);
+
+        if ($encoding === 'B') {
+            $bytes = base64_decode($text, true);
+
+            if ($bytes === false) {
+                return $original;
+            }
+        } elseif ($encoding === 'Q') {
+            $bytes = quoted_printable_decode(str_replace('_', ' ', $text));
+        } else {
+            return $original;
+        }
+
+        return self::convertToUtf8($bytes, $charset);
+    }
+
+    /**
+     * Convert decoded bytes to UTF-8 when possible.
+     *
+     * @param string $bytes   Decoded raw bytes.
+     * @param string $charset Source charset.
+     *
+     * @return string UTF-8 text or original bytes on failure.
+     */
+    private static function convertToUtf8(string $bytes, string $charset): string
+    {
+        $normalized = strtoupper(str_replace('_', '-', trim($charset)));
+        $aliases = [
+            'UTF8' => 'UTF-8',
+            'US-ASCII' => 'ASCII',
+            'ISO8859-1' => 'ISO-8859-1',
+            'ISO-8859-1' => 'ISO-8859-1',
+            'LATIN1' => 'ISO-8859-1',
+            'CP1252' => 'WINDOWS-1252',
+            'WIN-1252' => 'WINDOWS-1252',
+            'WINDOWS-1252' => 'WINDOWS-1252',
+        ];
+        $normalized = $aliases[$normalized] ?? $normalized;
+
+        if ($normalized === 'UTF-8' || $normalized === 'ASCII') {
+            return $bytes;
+        }
+
+        if (function_exists('mb_convert_encoding')) {
+            $converted = @mb_convert_encoding($bytes, 'UTF-8', $normalized);
+
+            if (is_string($converted) && $converted !== '') {
+                return $converted;
+            }
+
+            // Empty string can be a valid conversion of empty input.
+            if (is_string($converted) && $bytes === '') {
+                return $converted;
+            }
+        }
+
+        if (function_exists('iconv')) {
+            $converted = @iconv($normalized, 'UTF-8//IGNORE', $bytes);
+
+            if (is_string($converted)) {
+                return $converted;
+            }
+        }
+
+        if ($normalized === 'ISO-8859-1') {
+            return self::iso88591ToUtf8($bytes);
+        }
+
+        if ($normalized === 'WINDOWS-1252') {
+            return self::windows1252ToUtf8($bytes);
+        }
+
+        return $bytes;
+    }
+
+    /**
+     * Convert ISO-8859-1 bytes to UTF-8 without extensions.
+     *
+     * @param string $bytes ISO-8859-1 text.
+     *
+     * @return string UTF-8 text.
+     */
+    private static function iso88591ToUtf8(string $bytes): string
+    {
+        $result = '';
+        $length = strlen($bytes);
+
+        for ($i = 0; $i < $length; $i++) {
+            $code = ord($bytes[$i]);
+
+            if ($code < 0x80) {
+                $result .= $bytes[$i];
+                continue;
+            }
+
+            $result .= chr(0xC0 | ($code >> 6));
+            $result .= chr(0x80 | ($code & 0x3F));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert Windows-1252 bytes to UTF-8 without extensions.
+     *
+     * @param string $bytes Windows-1252 text.
+     *
+     * @return string UTF-8 text.
+     */
+    private static function windows1252ToUtf8(string $bytes): string
+    {
+        static $map = [
+            0x80 => "\xE2\x82\xAC",
+            0x82 => "\xE2\x80\x9A",
+            0x83 => "\xC6\x92",
+            0x84 => "\xE2\x80\x9E",
+            0x85 => "\xE2\x80\xA6",
+            0x86 => "\xE2\x80\xA0",
+            0x87 => "\xE2\x80\xA1",
+            0x88 => "\xCB\x86",
+            0x89 => "\xE2\x80\xB0",
+            0x8A => "\xC5\xA0",
+            0x8B => "\xE2\x80\xB9",
+            0x8C => "\xC5\x92",
+            0x8E => "\xC5\xBD",
+            0x91 => "\xE2\x80\x98",
+            0x92 => "\xE2\x80\x99",
+            0x93 => "\xE2\x80\x9C",
+            0x94 => "\xE2\x80\x9D",
+            0x95 => "\xE2\x80\xA2",
+            0x96 => "\xE2\x80\x93",
+            0x97 => "\xE2\x80\x94",
+            0x98 => "\xCB\x9C",
+            0x99 => "\xE2\x84\xA2",
+            0x9A => "\xC5\xA1",
+            0x9B => "\xE2\x80\xBA",
+            0x9C => "\xC5\x93",
+            0x9E => "\xC5\xBE",
+            0x9F => "\xC5\xB8",
+        ];
+
+        $result = '';
+        $length = strlen($bytes);
+
+        for ($i = 0; $i < $length; $i++) {
+            $code = ord($bytes[$i]);
+
+            if ($code < 0x80) {
+                $result .= $bytes[$i];
+                continue;
+            }
+
+            if (isset($map[$code])) {
+                $result .= $map[$code];
+                continue;
+            }
+
+            if ($code >= 0xA0) {
+                $result .= chr(0xC0 | ($code >> 6));
+                $result .= chr(0x80 | ($code & 0x3F));
+                continue;
+            }
+
+            // Undefined Windows-1252 slots (0x81, 0x8D, 0x8F, 0x90, 0x9D).
+            $result .= self::iso88591ToUtf8(chr($code));
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Rfc2047Test.php
+++ b/tests/Unit/Rfc2047Test.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Tests for RFC 2047 encoded header decoding.
+ *
+ * @category Tests
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Tests\Unit;
+
+use Erseco\Message;
+
+it(
+    'keeps getHeader raw while decoding UTF-8 base64 subjects',
+    function () {
+        $raw = '=?UTF-8?B?UmV1bmnDs24gZGUgcHJveWVjdG8=?=';
+        $message = Message::fromString("Subject: {$raw}\r\n\r\nBody");
+
+        expect($message->getHeader('Subject'))->toBe($raw)
+            ->and($message->getSubject())->toBe($raw)
+            ->and($message->getDecodedHeader('Subject'))->toBe('Reunión de proyecto')
+            ->and($message->getDecodedSubject())->toBe('Reunión de proyecto');
+    }
+);
+
+it(
+    'decodes ISO-8859-1 quoted-printable encoded words',
+    function () {
+        $raw = '=?ISO-8859-1?Q?Jos=E9_P=E9rez?=';
+        $message = Message::fromString("From: {$raw} <jose@example.com>\r\n\r\nBody");
+
+        expect($message->getFrom())->toBe($raw . ' <jose@example.com>')
+            ->and($message->getDecodedFrom())->toBe('José Pérez <jose@example.com>');
+    }
+);
+
+it(
+    'joins multiple adjacent UTF-8 Q encoded words',
+    function () {
+        $raw = '=?UTF-8?Q?Factura_?= =?UTF-8?Q?electr=C3=B3nica?=';
+        $message = Message::fromString("Subject: {$raw}\r\n\r\nBody");
+
+        expect($message->getDecodedSubject())->toBe('Factura electrónica');
+    }
+);
+
+it(
+    'preserves plain text mixed with encoded words',
+    function () {
+        $raw = 'Normal text =?UTF-8?B?Y2Fmw6k=?=';
+        $message = Message::fromString("Subject: {$raw}\r\n\r\nBody");
+
+        expect($message->getDecodedSubject())->toBe('Normal text café');
+    }
+);
+
+it(
+    'decodes case-insensitive encoding identifiers',
+    function () {
+        $raw = '=?utf-8?b?Y2Fmw6k=?=';
+        $message = Message::fromString("Subject: {$raw}\r\n\r\nBody");
+
+        expect($message->getDecodedSubject())->toBe('café');
+    }
+);
+
+it(
+    'decodes windows-1252 encoded words',
+    function () {
+        // "café" in Windows-1252 is 63 61 66 E9 → base64: Y2Fm6Q==
+        $raw = '=?Windows-1252?B?Y2Fm6Q==?=';
+        $message = Message::fromString("Subject: {$raw}\r\n\r\nBody");
+
+        expect($message->getDecodedSubject())->toBe('café');
+    }
+);
+
+it(
+    'decodes folded encoded headers',
+    function () {
+        $message = Message::fromString(
+            "Subject: =?UTF-8?B?UmV1bmk=?=\r\n"
+            . " =?UTF-8?B?w7Nu?= de proyecto\r\n\r\nBody"
+        );
+
+        expect($message->getDecodedSubject())->toBe('Reunión de proyecto');
+    }
+);
+
+it(
+    'leaves malformed encoded words without data loss',
+    function () {
+        $raw = '=?UTF-8?B?not-valid-base64!!!?= plain =?broken?= end';
+        $message = Message::fromString("Subject: {$raw}\r\n\r\nBody");
+
+        expect($message->getDecodedSubject())->toContain('plain')
+            ->and($message->getDecodedSubject())->toContain('end')
+            ->and($message->getDecodedHeader('Subject'))->not->toBeEmpty();
+    }
+);
+
+it(
+    'decodes To and Reply-To convenience accessors',
+    function () {
+        $encoded = '=?UTF-8?Q?Ana?= <ana@example.com>';
+        $message = Message::fromString(
+            "To: {$encoded}\r\n"
+            . "Reply-To: {$encoded}\r\n\r\nBody"
+        );
+
+        expect($message->getDecodedTo())->toBe('Ana <ana@example.com>')
+            ->and($message->getDecodedReplyTo())->toBe('Ana <ana@example.com>');
+    }
+);
+
+it(
+    'returns default when decoded header is missing',
+    function () {
+        $message = Message::fromString("Subject: Hello\r\n\r\nBody");
+
+        expect($message->getDecodedHeader('X-Missing', 'fallback'))->toBe('fallback');
+    }
+);


### PR DESCRIPTION
## Summary

- Add `Rfc2047` decoder for MIME encoded-words (`B` and `Q`).
- Expose `getDecodedHeader()` plus `getDecodedSubject()`, `getDecodedFrom()`, `getDecodedTo()`, and `getDecodedReplyTo()`.
- Keep `getHeader()` / `getSubject()` returning the raw unfolded value.
- Support UTF-8, ISO-8859-1, and Windows-1252 without mandatory extensions.
- Document raw vs decoded accessors in the README.

## Test plan

- [x] `composer validate --strict`, `dump-autoload --strict-psr`, `audit`, `lint`, `test`
- [x] New unit tests for base64, Q-encoding, adjacent words, mixed text, folding, case-insensitive encodings, Windows-1252, and malformed tokens
- [x] PHP 8.0–8.5 matrix via Docker
- [x] PHP 8.0 prefer-lowest

