### PR TITLE
Support RFC 2231 continuation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ $firstPart->isHtml();                     // true if it's an HTML part
 $firstPart->isText();                     // true if it's a text part
 $firstPart->isAttachment();               // true if it's an attachment
 $firstPart->getFilename();                // name of the file if attachment
+                                          // supports filename=, filename*=, and RFC 2231
+                                          // continuations (filename*0*=, filename*1*=, …)
 $firstPart->getSize();                    // size of content in bytes
 ```
+
 
 ## Credits
 

--- a/src/MessagePart.php
+++ b/src/MessagePart.php
@@ -234,6 +234,11 @@ class MessagePart implements \JsonSerializable
     /**
      * Extract and decode a MIME header parameter.
      *
+     * Preference order:
+     * 1. RFC 2231 continuations (`name*0*=`, `name*1*=`, …)
+     * 2. Single extended parameter (`name*=`)
+     * 3. Regular parameter (`name=`)
+     *
      * @param string $headerName Header name.
      * @param string $parameter  Parameter name.
      *
@@ -245,6 +250,12 @@ class MessagePart implements \JsonSerializable
 
         if (!is_string($header) || $header === '') {
             return null;
+        }
+
+        $continued = $this->getContinuedParameter($header, $parameter);
+
+        if ($continued !== null) {
+            return $continued;
         }
 
         $extendedPattern = '/(?:^|;)\s*'
@@ -271,6 +282,83 @@ class MessagePart implements \JsonSerializable
     }
 
     /**
+     * Assemble an RFC 2231 continued parameter value.
+     *
+     * Segments may appear out of order. Duplicate indexes keep the last value.
+     * Missing indexes are skipped so remaining segments still concatenate.
+     *
+     * @param string $header    Full header value.
+     * @param string $parameter Base parameter name (e.g. filename).
+     *
+     * @return string|null Assembled value or null when no continuations exist.
+     */
+    protected function getContinuedParameter(string $header, string $parameter): ?string
+    {
+        $pattern = '/(?:^|;)\s*'
+            . preg_quote($parameter, '/')
+            . '\*(?<index>\d+)(?<encoded>\*)?\s*=\s*'
+            . '(?:"(?<quoted>(?:\\\\.|[^"])*)"|(?<plain>[^;]*))/i';
+
+        if (!preg_match_all($pattern, $header, $matches, PREG_SET_ORDER)) {
+            return null;
+        }
+
+        $segments = [];
+
+        foreach ($matches as $match) {
+            $index = (int) $match['index'];
+            $encoded = ($match['encoded'] ?? '') === '*';
+            $raw = $match['quoted'] !== '' ? $match['quoted'] : trim($match['plain']);
+            $raw = stripcslashes($raw);
+
+            if ($encoded) {
+                $segments[$index] = [
+                    'encoded' => true,
+                    'value' => $raw,
+                ];
+            } else {
+                $segments[$index] = [
+                    'encoded' => false,
+                    'value' => $raw,
+                ];
+            }
+        }
+
+        if ($segments === []) {
+            return null;
+        }
+
+        ksort($segments, SORT_NUMERIC);
+
+        $charset = null;
+        $parts = [];
+
+        foreach ($segments as $index => $segment) {
+            $value = $segment['value'];
+
+            if ($segment['encoded']) {
+                if ($index === 0 && preg_match("/^([^']*)'[^']*'(.*)$/", $value, $charsetMatch)) {
+                    $charset = $charsetMatch[1];
+                    $value = $charsetMatch[2];
+                }
+
+                $parts[] = rawurldecode($value);
+                continue;
+            }
+
+            $parts[] = $value;
+        }
+
+        $joined = implode('', $parts);
+
+        if ($charset !== null && $charset !== '') {
+            return $this->convertParameterCharset($joined, $charset);
+        }
+
+        return $joined;
+    }
+
+    /**
      * Decode an RFC 2231 extended parameter value.
      *
      * @param string $value Encoded parameter value.
@@ -286,18 +374,57 @@ class MessagePart implements \JsonSerializable
         $charset = $matches[1];
         $decoded = rawurldecode($matches[2]);
 
-        if (
-            $charset !== ''
-            && strcasecmp($charset, 'UTF-8') !== 0
-            && function_exists('iconv')
-        ) {
-            $converted = @iconv($charset, 'UTF-8//IGNORE', $decoded);
+        return $this->convertParameterCharset($decoded, $charset);
+    }
 
-            if ($converted !== false) {
+    /**
+     * Convert parameter bytes to UTF-8 when a charset is declared.
+     *
+     * Falls back to the original bytes when conversion is unavailable.
+     *
+     * @param string $bytes   Decoded parameter bytes.
+     * @param string $charset Source charset.
+     *
+     * @return string Converted or original value.
+     */
+    protected function convertParameterCharset(string $bytes, string $charset): string
+    {
+        if ($charset === '' || strcasecmp($charset, 'UTF-8') === 0) {
+            return $bytes;
+        }
+
+        // Reuse the RFC 2047 charset path by wrapping as a trivial B word.
+        // Decode only the charset conversion logic through a synthetic call.
+        if (function_exists('mb_convert_encoding')) {
+            $converted = @mb_convert_encoding($bytes, 'UTF-8', $charset);
+
+            if (is_string($converted) && ($converted !== '' || $bytes === '')) {
                 return $converted;
             }
         }
 
-        return $decoded;
+        if (function_exists('iconv')) {
+            $converted = @iconv($charset, 'UTF-8//IGNORE', $bytes);
+
+            if (is_string($converted)) {
+                return $converted;
+            }
+        }
+
+        $normalized = strtoupper(str_replace('_', '-', $charset));
+
+        if ($normalized === 'ISO-8859-1' || $normalized === 'ISO8859-1' || $normalized === 'LATIN1') {
+            return Rfc2047::decode("=?ISO-8859-1?B?" . base64_encode($bytes) . "?=");
+        }
+
+        if (
+            $normalized === 'WINDOWS-1252'
+            || $normalized === 'CP1252'
+            || $normalized === 'WIN-1252'
+        ) {
+            return Rfc2047::decode("=?Windows-1252?B?" . base64_encode($bytes) . "?=");
+        }
+
+        return $bytes;
     }
 }

--- a/tests/Unit/Rfc2231ContinuationTest.php
+++ b/tests/Unit/Rfc2231ContinuationTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * Tests for RFC 2231 continued filename parameters.
+ *
+ * @category Tests
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Tests\Unit;
+
+use Erseco\Message;
+use Erseco\MessagePart;
+
+it(
+    'assembles UTF-8 filename continuations',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Type' => 'application/pdf',
+                'Content-Disposition' => "attachment;\r\n"
+                    . " filename*0*=UTF-8''quarterly%20;\r\n"
+                    . " filename*1*=report%20;\r\n"
+                    . " filename*2*=2026.pdf",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('quarterly report 2026.pdf')
+            ->and($part->isAttachment())->toBeTrue();
+    }
+);
+
+it(
+    'supports ISO-8859-1 continued filenames',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => "attachment; "
+                    . "filename*0*=ISO-8859-1''caf%E9%20; "
+                    . "filename*1*=menu.pdf",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('café menu.pdf');
+    }
+);
+
+it(
+    'supports quoted continuation segments and punctuation',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => 'attachment; '
+                    . 'filename*0="invoice (final)_"; '
+                    . 'filename*1="2026-Q1.pdf"',
+            ]
+        );
+
+        expect($part->getFilename())->toBe('invoice (final)_2026-Q1.pdf');
+    }
+);
+
+it(
+    'sorts out-of-order continuation segments',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => "attachment; "
+                    . "filename*2*=c.pdf; "
+                    . "filename*0*=UTF-8''a%20; "
+                    . "filename*1*=b%20",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('a b c.pdf');
+    }
+);
+
+it(
+    'skips missing middle segments deterministically',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => "attachment; "
+                    . "filename*0*=UTF-8''start-; "
+                    . "filename*2*=end.pdf",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('start-end.pdf');
+    }
+);
+
+it(
+    'keeps the last value for duplicate continuation indexes',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => "attachment; "
+                    . "filename*0*=UTF-8''old; "
+                    . "filename*0*=UTF-8''new; "
+                    . "filename*1*=.txt",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('new.txt');
+    }
+);
+
+it(
+    'falls back to plain filename parameter',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => 'attachment; filename="plain.txt"',
+            ]
+        );
+
+        expect($part->getFilename())->toBe('plain.txt');
+    }
+);
+
+it(
+    'keeps single filename* extended parameter behaviour',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => "attachment; filename*=UTF-8''caf%C3%A9.txt",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('café.txt');
+    }
+);
+
+it(
+    'prefers Content-Disposition filename over Content-Type name',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Type' => 'application/octet-stream; name="from-type.bin"',
+                'Content-Disposition' => "attachment; "
+                    . "filename*0*=UTF-8''from-; "
+                    . "filename*1*=disposition.bin",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('from-disposition.bin');
+    }
+);
+
+it(
+    'supports name* continuations on Content-Type when disposition lacks a filename',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Type' => "application/pdf; "
+                    . "name*0*=UTF-8''type-; "
+                    . "name*1*=name.pdf",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('type-name.pdf');
+    }
+);
+
+it(
+    'handles mixed-case parameter names',
+    function () {
+        $part = new MessagePart(
+            'data',
+            [
+                'Content-Disposition' => "Attachment; "
+                    . "FileName*0*=UTF-8''Case; "
+                    . "FILENAME*1*=.pdf",
+            ]
+        );
+
+        expect($part->getFilename())->toBe('Case.pdf');
+    }
+);
+
+it(
+    'parses continued filenames from a full message string',
+    function () {
+        $raw = "From: a@example.com\r\n"
+            . "To: b@example.com\r\n"
+            . "Subject: attachment\r\n"
+            . "MIME-Version: 1.0\r\n"
+            . "Content-Type: multipart/mixed; boundary=\"b1\"\r\n\r\n"
+            . "--b1\r\n"
+            . "Content-Type: text/plain\r\n\r\n"
+            . "Hello\r\n"
+            . "--b1\r\n"
+            . "Content-Type: application/pdf\r\n"
+            . "Content-Disposition: attachment;\r\n"
+            . " filename*0*=UTF-8''quarterly%20;\r\n"
+            . " filename*1*=report%20;\r\n"
+            . " filename*2*=2026.pdf\r\n"
+            . "Content-Transfer-Encoding: base64\r\n\r\n"
+            . "AA==\r\n"
+            . "--b1--\r\n";
+
+        $message = Message::fromString($raw);
+
+        expect($message->getAttachments())->toHaveCount(1)
+            ->and($message->getAttachments()[0]->getFilename())
+            ->toBe('quarterly report 2026.pdf');
+    }
+);


### PR DESCRIPTION
## Summary

- Assemble RFC 2231 continued parameters (`filename*0*=`, `filename*1*=`, …).
- Support encoded and unencoded segments, quoted values, out-of-order indexes, missing segments, and duplicates (last wins).
- Prefer `Content-Disposition` filename over `Content-Type` name, including `name*` continuations.
- Preserve plain `filename=` and single `filename*=` behaviour.
- Document continuation support in the README.

## Test plan

- [x] Unit tests for UTF-8/ISO-8859-1, punctuation, ordering, missing/duplicate indexes, fallbacks, case-insensitive names, and full-message parsing
- [x] `composer lint` and full Pest suite
- [x] PHP 8.0–8.5 Docker matrix
