### PR TITLE
Add optional text content conversion to UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ $firstPart = $parts[0];
 $firstPart->getHeaders();                 // array of all headers for this part
 $firstPart->getHeader('Content-Type');    // get specific header
 $firstPart->getContentType();             // 'text/html; charset="utf-8"'
-$firstPart->getContent();                 // '<html><body>....'
+$firstPart->getContent();                 // transfer-decoded content (no charset conversion)
+$firstPart->getContentAsUtf8();           // text/* parts converted to UTF-8 when possible
+$firstPart->getCharset();                 // charset from Content-Type, or null
 $firstPart->isHtml();                     // true if it's an HTML part
+
 $firstPart->isText();                     // true if it's a text part
 $firstPart->isAttachment();               // true if it's an attachment
 $firstPart->getFilename();                // name of the file if attachment

--- a/src/MessagePart.php
+++ b/src/MessagePart.php
@@ -81,6 +81,9 @@ class MessagePart implements \JsonSerializable
     /**
      * Get the decoded content of this message part.
      *
+     * Decodes Content-Transfer-Encoding only. Charset conversion is not applied.
+     * Use getContentAsUtf8() when UTF-8 text is required.
+     *
      * @return string The decoded content.
      */
     public function getContent(): string
@@ -98,6 +101,60 @@ class MessagePart implements \JsonSerializable
         }
 
         return $this->content;
+    }
+
+    /**
+     * Get transfer-decoded content converted to UTF-8 when the part is textual.
+     *
+     * Behaviour:
+     * - Decodes Content-Transfer-Encoding first (same as getContent()).
+     * - Converts only text/* parts using the Content-Type charset parameter.
+     * - Leaves binary/non-text parts unchanged.
+     * - Missing, unknown, or failed conversions return the transfer-decoded bytes.
+     *
+     * @return string UTF-8 text when conversion succeeds; otherwise decoded bytes.
+     */
+    public function getContentAsUtf8(): string
+    {
+        $content = $this->getContent();
+
+        if (!$this->isTextualPart()) {
+            return $content;
+        }
+
+        $charset = $this->getCharset();
+
+        if ($charset === null || $charset === '') {
+            return $content;
+        }
+
+        return $this->convertParameterCharset($content, $charset);
+    }
+
+    /**
+     * Read the charset parameter from Content-Type.
+     *
+     * @return string|null Charset name or null when absent.
+     */
+    public function getCharset(): ?string
+    {
+        $charset = $this->getHeaderParameter('Content-Type', 'charset');
+
+        if ($charset === null || $charset === '') {
+            return null;
+        }
+
+        return trim($charset, " \t\"'");
+    }
+
+    /**
+     * Whether this part is a textual MIME type eligible for charset conversion.
+     *
+     * @return bool True for text/* content types.
+     */
+    protected function isTextualPart(): bool
+    {
+        return str_starts_with(strtolower($this->getContentType()), 'text/');
     }
 
     /**
@@ -389,42 +446,88 @@ class MessagePart implements \JsonSerializable
      */
     protected function convertParameterCharset(string $bytes, string $charset): string
     {
-        if ($charset === '' || strcasecmp($charset, 'UTF-8') === 0) {
+        $normalized = strtoupper(str_replace('_', '-', trim($charset)));
+        $aliases = [
+            'UTF8' => 'UTF-8',
+            'US-ASCII' => 'ASCII',
+            'ISO8859-1' => 'ISO-8859-1',
+            'LATIN1' => 'ISO-8859-1',
+            'CP1252' => 'WINDOWS-1252',
+            'WIN-1252' => 'WINDOWS-1252',
+        ];
+        $normalized = $aliases[$normalized] ?? $normalized;
+
+        if (
+            $normalized === ''
+            || $normalized === 'UTF-8'
+            || $normalized === 'ASCII'
+        ) {
             return $bytes;
         }
 
-        // Reuse the RFC 2047 charset path by wrapping as a trivial B word.
-        // Decode only the charset conversion logic through a synthetic call.
-        if (function_exists('mb_convert_encoding')) {
-            $converted = @mb_convert_encoding($bytes, 'UTF-8', $charset);
+        if ($normalized === 'ISO-8859-1') {
+            return Rfc2047::decode('=?ISO-8859-1?B?' . base64_encode($bytes) . '?=');
+        }
 
-            if (is_string($converted) && ($converted !== '' || $bytes === '')) {
-                return $converted;
+        if ($normalized === 'WINDOWS-1252') {
+            return Rfc2047::decode('=?Windows-1252?B?' . base64_encode($bytes) . '?=');
+        }
+
+        $converted = $this->convertWithOptionalExtensions($bytes, $normalized);
+
+        return $converted ?? $bytes;
+    }
+
+    /**
+     * Attempt charset conversion using optional PHP extensions.
+     *
+     * @param string $bytes   Source bytes.
+     * @param string $charset Source charset name.
+     *
+     * @return string|null Converted UTF-8 string or null on failure.
+     */
+    protected function convertWithOptionalExtensions(string $bytes, string $charset): ?string
+    {
+        if (function_exists('mb_convert_encoding')) {
+            try {
+                set_error_handler(static function (): bool {
+                    return true;
+                });
+
+                try {
+                    $converted = mb_convert_encoding($bytes, 'UTF-8', $charset);
+                } finally {
+                    restore_error_handler();
+                }
+
+                if (is_string($converted) && ($converted !== '' || $bytes === '')) {
+                    return $converted;
+                }
+            } catch (\Throwable $exception) {
+                // Unknown charsets may throw; fall through.
             }
         }
 
         if (function_exists('iconv')) {
-            $converted = @iconv($charset, 'UTF-8//IGNORE', $bytes);
+            try {
+                set_error_handler(static function (): bool {
+                    return true;
+                });
 
-            if (is_string($converted)) {
-                return $converted;
+                try {
+                    $converted = iconv($charset, 'UTF-8//IGNORE', $bytes);
+                } finally {
+                    restore_error_handler();
+                }
+
+                if (is_string($converted)) {
+                    return $converted;
+                }
+            } catch (\Throwable $exception) {
+                // Unknown charsets may throw; fall through.
             }
         }
 
-        $normalized = strtoupper(str_replace('_', '-', $charset));
-
-        if ($normalized === 'ISO-8859-1' || $normalized === 'ISO8859-1' || $normalized === 'LATIN1') {
-            return Rfc2047::decode("=?ISO-8859-1?B?" . base64_encode($bytes) . "?=");
-        }
-
-        if (
-            $normalized === 'WINDOWS-1252'
-            || $normalized === 'CP1252'
-            || $normalized === 'WIN-1252'
-        ) {
-            return Rfc2047::decode("=?Windows-1252?B?" . base64_encode($bytes) . "?=");
-        }
-
-        return $bytes;
+        return null;
     }
 }

--- a/src/Rfc2047.php
+++ b/src/Rfc2047.php
@@ -126,23 +126,42 @@ final class Rfc2047
         }
 
         if (function_exists('mb_convert_encoding')) {
-            $converted = @mb_convert_encoding($bytes, 'UTF-8', $normalized);
+            try {
+                set_error_handler(static function (): bool {
+                    return true;
+                });
 
-            if (is_string($converted) && $converted !== '') {
-                return $converted;
-            }
+                try {
+                    $converted = mb_convert_encoding($bytes, 'UTF-8', $normalized);
+                } finally {
+                    restore_error_handler();
+                }
 
-            // Empty string can be a valid conversion of empty input.
-            if (is_string($converted) && $bytes === '') {
-                return $converted;
+                if (is_string($converted) && ($converted !== '' || $bytes === '')) {
+                    return $converted;
+                }
+            } catch (\Throwable $exception) {
+                // Unknown charsets may throw on newer PHP versions.
             }
         }
 
         if (function_exists('iconv')) {
-            $converted = @iconv($normalized, 'UTF-8//IGNORE', $bytes);
+            try {
+                set_error_handler(static function (): bool {
+                    return true;
+                });
 
-            if (is_string($converted)) {
-                return $converted;
+                try {
+                    $converted = iconv($normalized, 'UTF-8//IGNORE', $bytes);
+                } finally {
+                    restore_error_handler();
+                }
+
+                if (is_string($converted)) {
+                    return $converted;
+                }
+            } catch (\Throwable $exception) {
+                // Unknown charsets may throw on newer PHP versions.
             }
         }
 

--- a/tests/Unit/CharsetConversionTest.php
+++ b/tests/Unit/CharsetConversionTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * Tests for optional text content conversion to UTF-8.
+ *
+ * @category Tests
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Tests\Unit;
+
+use Erseco\Message;
+use Erseco\MessagePart;
+
+it(
+    'converts quoted-printable ISO-8859-1 text to UTF-8',
+    function () {
+        $part = new MessagePart(
+            'Caf=E9',
+            [
+                'Content-Type' => 'text/plain; charset=ISO-8859-1',
+                'Content-Transfer-Encoding' => 'quoted-printable',
+            ]
+        );
+
+        expect($part->getContent())->toBe("Caf\xE9")
+            ->and($part->getContentAsUtf8())->toBe('Café')
+            ->and($part->getCharset())->toBe('ISO-8859-1');
+    }
+);
+
+it(
+    'converts base64 Windows-1252 text to UTF-8',
+    function () {
+        // "café" in Windows-1252
+        $part = new MessagePart(
+            base64_encode("caf\xE9"),
+            [
+                'Content-Type' => 'text/plain; charset="Windows-1252"',
+                'Content-Transfer-Encoding' => 'base64',
+            ]
+        );
+
+        expect($part->getContentAsUtf8())->toBe('café');
+    }
+);
+
+it(
+    'returns UTF-8 text unchanged',
+    function () {
+        $part = new MessagePart(
+            'Reunión',
+            ['Content-Type' => 'text/plain; charset=utf-8']
+        );
+
+        expect($part->getContentAsUtf8())->toBe('Reunión')
+            ->and($part->getContent())->toBe('Reunión');
+    }
+);
+
+it(
+    'treats US-ASCII as already compatible',
+    function () {
+        $part = new MessagePart(
+            'Hello ASCII',
+            ['Content-Type' => 'text/plain; charset=us-ascii']
+        );
+
+        expect($part->getContentAsUtf8())->toBe('Hello ASCII');
+    }
+);
+
+it(
+    'returns transfer-decoded content for unknown charset',
+    function () {
+        $part = new MessagePart(
+            "Caf\xE9",
+            ['Content-Type' => 'text/plain; charset=x-unknown-charset']
+        );
+
+        expect($part->getContentAsUtf8())->toBe("Caf\xE9")
+            ->and($part->getContent())->toBe("Caf\xE9");
+    }
+);
+
+it(
+    'returns content as-is when charset is missing',
+    function () {
+        $part = new MessagePart(
+            'No charset here',
+            ['Content-Type' => 'text/plain']
+        );
+
+        expect($part->getCharset())->toBeNull()
+            ->and($part->getContentAsUtf8())->toBe('No charset here');
+    }
+);
+
+it(
+    'converts HTML text parts',
+    function () {
+        $part = new MessagePart(
+            'Hola =E1',
+            [
+                'Content-Type' => 'text/html; charset=iso-8859-1',
+                'Content-Transfer-Encoding' => 'quoted-printable',
+            ]
+        );
+
+        expect($part->getContentAsUtf8())->toBe("Hola \xC3\xA1");
+    }
+);
+
+it(
+    'does not convert binary attachments',
+    function () {
+        $binary = "\x00\x01\xFF\xE9";
+        $part = new MessagePart(
+            base64_encode($binary),
+            [
+                'Content-Type' => 'application/octet-stream; charset=ISO-8859-1',
+                'Content-Transfer-Encoding' => 'base64',
+                'Content-Disposition' => 'attachment; filename="bin.dat"',
+            ]
+        );
+
+        expect($part->getContentAsUtf8())->toBe($binary)
+            ->and($part->getContent())->toBe($binary);
+    }
+);
+
+it(
+    'handles mixed-case charset names',
+    function () {
+        $part = new MessagePart(
+            "Caf\xE9",
+            ['Content-Type' => 'text/plain; Charset=Iso-8859-1']
+        );
+
+        expect($part->getContentAsUtf8())->toBe('Café');
+    }
+);
+
+it(
+    'does not throw on malformed sequences for declared UTF-8',
+    function () {
+        $invalid = "a\xC3"; // truncated multi-byte sequence
+        $part = new MessagePart(
+            $invalid,
+            ['Content-Type' => 'text/plain; charset=UTF-8']
+        );
+
+        expect($part->getContentAsUtf8())->toBe($invalid);
+    }
+);
+
+it(
+    'works through Message::fromString text parts',
+    function () {
+        $raw = "Content-Type: text/plain; charset=ISO-8859-1\r\n"
+            . "Content-Transfer-Encoding: quoted-printable\r\n\r\n"
+            . "Se=F1or";
+
+        $message = Message::fromString($raw);
+
+        expect($message->getTextPart()?->getContentAsUtf8())->toBe('Señor')
+            ->and($message->getTextPart()?->getContent())->toBe("Se\xF1or");
+    }
+);


### PR DESCRIPTION
## Summary

- Add `MessagePart::getContentAsUtf8()` for transfer-decoded text converted to UTF-8.
- Add `MessagePart::getCharset()` to read the Content-Type charset parameter.
- Leave `getContent()` unchanged (transfer decoding only).
- Convert only `text/*` parts; binary attachments remain untouched.
- Fall back safely for missing, unknown, or failing charsets without mandatory extensions.

## Test plan

- [x] ISO-8859-1 quoted-printable, Windows-1252 base64, UTF-8, US-ASCII
- [x] Unknown/missing charset, HTML text, binary attachments, mixed-case names
- [x] PHP 8.0–8.5 matrix
- [x] `composer lint` and full Pest suite
