### PR TITLE
Add configurable parser safety limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ $message = Message::fromString($rawEmail);
 // Or parse from a file directly
 $message = Message::fromFile('/path/to/email.eml');
 
+// Optional safety limits (defaults keep ordinary mail working)
+use Erseco\ParserOptions;
+
+$options = new ParserOptions(
+    maxMessageBytes: 10_485_760,   // 10 MiB raw message
+    maxParts: 1000,                // leaf MIME parts
+    maxDepth: 20,                  // nested multipart depth
+    maxHeaders: 500,               // headers per header block
+    maxHeaderLineLength: 998,      // bytes per header line
+    maxDecodedPartBytes: 10_485_760
+);
+
+$message = Message::fromString($rawEmail, false, $options);
+// Exceeding a limit throws Erseco\ParserLimitExceededException
+// with getLimitName(), getLimitValue(), and getActualValue().
+
 $message->getHeaders();                 // get all headers as array
 $message->getHeader('Content-Type');    // get specific header (raw unfolded value)
 $message->getContentType();             // 'multipart/mixed; boundary="----=_Part_1_1234567890"'

--- a/src/Message.php
+++ b/src/Message.php
@@ -33,46 +33,99 @@ class Message implements \JsonSerializable
 
     protected bool $ignoreSignature = false;
 
+    protected ParserOptions $options;
+
+    protected ParserContext $context;
+
     /**
      * Create a new Message instance.
      *
-     * @param string $message         The raw email message.
-     * @param bool   $ignoreSignature Whether to ignore message signatures.
+     * @param string              $message         The raw email message.
+     * @param bool                $ignoreSignature Whether to ignore message signatures.
+     * @param ParserOptions|null  $options         Optional safety limits.
+     * @param ParserContext|null  $context         Shared state for nested parsers.
+     *
+     * @throws ParserLimitExceededException When a configured limit is exceeded.
      */
-    public function __construct(string $message, bool $ignoreSignature = false)
-    {
-        $this->message = $message;
+    public function __construct(
+        string $message,
+        bool $ignoreSignature = false,
+        ?ParserOptions $options = null,
+        ?ParserContext $context = null
+    ) {
+        $this->options = $options ?? ($context !== null ? $context->options : ParserOptions::defaults());
+        $this->context = $context ?? new ParserContext($this->options);
         $this->ignoreSignature = $ignoreSignature;
+
+        if ($context === null) {
+            $this->assertWithinLimit(
+                'maxMessageBytes',
+                $this->options->maxMessageBytes,
+                strlen($message)
+            );
+        }
+
+        if ($this->context->depth > $this->options->maxDepth) {
+            $this->assertWithinLimit(
+                'maxDepth',
+                $this->options->maxDepth,
+                $this->context->depth
+            );
+        }
+
+        $this->message = $message;
         $this->parse();
     }
 
     /**
      * Create a Message instance from a string.
      *
-     * @param string $message         The raw email message string.
-     * @param bool   $ignoreSignature Whether to ignore message signatures.
+     * @param string             $message         The raw email message string.
+     * @param bool               $ignoreSignature Whether to ignore message signatures.
+     * @param ParserOptions|null $options         Optional safety limits.
      *
      * @return self
      */
-    public static function fromString(string $message, bool $ignoreSignature = false): self
-    {
-        return new self($message, $ignoreSignature);
+    public static function fromString(
+        string $message,
+        bool $ignoreSignature = false,
+        ?ParserOptions $options = null
+    ): self {
+        return new self($message, $ignoreSignature, $options);
     }
 
     /**
      * Create a Message instance from a file.
      *
-     * @param string $path            Path to the email message file.
-     * @param bool   $ignoreSignature Whether to ignore message signatures.
+     * @param string             $path            Path to the email message file.
+     * @param bool               $ignoreSignature Whether to ignore message signatures.
+     * @param ParserOptions|null $options         Optional safety limits.
      *
-     * @throws \RuntimeException When the file cannot be read.
+     * @throws \RuntimeException            When the file cannot be read.
+     * @throws ParserLimitExceededException When the file exceeds maxMessageBytes.
      *
      * @return self
      */
-    public static function fromFile(string $path, bool $ignoreSignature = false): self
-    {
+    public static function fromFile(
+        string $path,
+        bool $ignoreSignature = false,
+        ?ParserOptions $options = null
+    ): self {
         if (!is_readable($path)) {
             throw new \RuntimeException(sprintf('Unable to read email message from "%s".', $path));
+        }
+
+        $options = $options ?? ParserOptions::defaults();
+        $fileSize = filesize($path);
+
+        if ($fileSize !== false) {
+            if ($fileSize > $options->maxMessageBytes) {
+                throw new ParserLimitExceededException(
+                    'maxMessageBytes',
+                    $options->maxMessageBytes,
+                    $fileSize
+                );
+            }
         }
 
         $message = file_get_contents($path);
@@ -81,7 +134,17 @@ class Message implements \JsonSerializable
             throw new \RuntimeException(sprintf('Unable to read email message from "%s".', $path));
         }
 
-        return new self($message, $ignoreSignature);
+        return new self($message, $ignoreSignature, $options);
+    }
+
+    /**
+     * Get the active parser options.
+     *
+     * @return ParserOptions
+     */
+    public function getOptions(): ParserOptions
+    {
+        return $this->options;
     }
 
     /**
@@ -449,10 +512,21 @@ class Message implements \JsonSerializable
 
         if (str_starts_with(strtolower($contentType), 'multipart/')) {
             $innerMessage = $this->buildHeaderBlock($headers) . "\r\n\r\n" . $body;
-            $innerParser = new self($innerMessage, $this->ignoreSignature);
+            $this->context->depth++;
 
-            foreach ($innerParser->getParts() as $innerPart) {
-                $this->parts[] = $innerPart;
+            try {
+                $innerParser = new self(
+                    $innerMessage,
+                    $this->ignoreSignature,
+                    $this->options,
+                    $this->context
+                );
+
+                foreach ($innerParser->getParts() as $innerPart) {
+                    $this->parts[] = $innerPart;
+                }
+            } finally {
+                $this->context->depth--;
             }
 
             return;
@@ -462,7 +536,22 @@ class Message implements \JsonSerializable
             $body = $this->stripSignature($body);
         }
 
-        $this->parts[] = new MessagePart($body, $headers);
+        $this->context->partCount++;
+        $this->assertWithinLimit(
+            'maxParts',
+            $this->options->maxParts,
+            $this->context->partCount
+        );
+
+        $part = new MessagePart($body, $headers);
+        $decodedSize = strlen($part->getContent());
+        $this->assertWithinLimit(
+            'maxDecodedPartBytes',
+            $this->options->maxDecodedPartBytes,
+            $decodedSize
+        );
+
+        $this->parts[] = $part;
     }
 
     /**
@@ -479,6 +568,12 @@ class Message implements \JsonSerializable
         $lines = preg_split('/\r\n|\n|\r/', $headerBlock) ?: [];
 
         foreach ($lines as $line) {
+            $this->assertWithinLimit(
+                'maxHeaderLineLength',
+                $this->options->maxHeaderLineLength,
+                strlen($line)
+            );
+
             if ($currentKey !== null && preg_match('/^[\t ]/', $line)) {
                 $headers[$currentKey] .= "\n" . $line;
                 continue;
@@ -505,9 +600,33 @@ class Message implements \JsonSerializable
 
             $headers[$matches['key']] = $matches['value'];
             $currentKey = $matches['key'];
+
+            $this->assertWithinLimit(
+                'maxHeaders',
+                $this->options->maxHeaders,
+                count($headers)
+            );
         }
 
         return $headers;
+    }
+
+    /**
+     * Throw when a measured value exceeds a configured limit.
+     *
+     * @param string $limitName   Option name.
+     * @param int    $limitValue  Configured maximum.
+     * @param int    $actualValue Observed value.
+     *
+     * @throws ParserLimitExceededException When actualValue is greater than limitValue.
+     *
+     * @return void
+     */
+    protected function assertWithinLimit(string $limitName, int $limitValue, int $actualValue): void
+    {
+        if ($actualValue > $limitValue) {
+            throw new ParserLimitExceededException($limitName, $limitValue, $actualValue);
+        }
     }
 
     /**

--- a/src/ParserContext.php
+++ b/src/ParserContext.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Shared mutable parser state for nested MIME parsing.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Erseco;
+
+/**
+ * Tracks counters that must be shared across nested Message parsers.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+final class ParserContext
+{
+    public int $partCount = 0;
+
+    public int $depth = 0;
+
+    /**
+     * @param ParserOptions $options Active parser limits.
+     */
+    public function __construct(public ParserOptions $options)
+    {
+    }
+}

--- a/src/ParserLimitExceededException.php
+++ b/src/ParserLimitExceededException.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Exception thrown when a parser safety limit is exceeded.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Erseco;
+
+/**
+ * Identifies which parser limit was exceeded and the observed value.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+class ParserLimitExceededException extends \RuntimeException
+{
+    private string $limitName;
+
+    private int $limitValue;
+
+    private int $actualValue;
+
+    /**
+     * @param string $limitName   Option name that was exceeded.
+     * @param int    $limitValue  Configured limit.
+     * @param int    $actualValue Observed value that exceeded the limit.
+     * @param string $message     Optional custom message.
+     */
+    public function __construct(
+        string $limitName,
+        int $limitValue,
+        int $actualValue,
+        string $message = ''
+    ) {
+        $this->limitName = $limitName;
+        $this->limitValue = $limitValue;
+        $this->actualValue = $actualValue;
+
+        if ($message === '') {
+            $message = sprintf(
+                'Parser limit "%s" exceeded: limit=%d, actual=%d.',
+                $limitName,
+                $limitValue,
+                $actualValue
+            );
+        }
+
+        parent::__construct($message);
+    }
+
+    /**
+     * @return string Name of the exceeded limit option.
+     */
+    public function getLimitName(): string
+    {
+        return $this->limitName;
+    }
+
+    /**
+     * @return int Configured limit value.
+     */
+    public function getLimitValue(): int
+    {
+        return $this->limitValue;
+    }
+
+    /**
+     * @return int Observed value that exceeded the limit.
+     */
+    public function getActualValue(): int
+    {
+        return $this->actualValue;
+    }
+}

--- a/src/ParserOptions.php
+++ b/src/ParserOptions.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Configurable safety limits for the MIME message parser.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Erseco;
+
+/**
+ * Parser safety limits.
+ *
+ * Defaults are generous enough for ordinary email while bounding pathological
+ * input. Existing constructors keep these defaults when no options are passed.
+ *
+ * @category Library
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+final class ParserOptions
+{
+    public const DEFAULT_MAX_MESSAGE_BYTES = 10485760;
+
+    public const DEFAULT_MAX_PARTS = 1000;
+
+    public const DEFAULT_MAX_DEPTH = 20;
+
+    public const DEFAULT_MAX_HEADERS = 500;
+
+    public const DEFAULT_MAX_HEADER_LINE_LENGTH = 998;
+
+    public const DEFAULT_MAX_DECODED_PART_BYTES = 10485760;
+
+    /**
+     * @param int $maxMessageBytes       Maximum raw message size in bytes.
+     * @param int $maxParts              Maximum number of leaf MIME parts.
+     * @param int $maxDepth              Maximum nested multipart depth.
+     * @param int $maxHeaders            Maximum headers per header block.
+     * @param int $maxHeaderLineLength   Maximum length of a single header line.
+     * @param int $maxDecodedPartBytes   Maximum decoded size of any leaf part.
+     */
+    public function __construct(
+        public int $maxMessageBytes = self::DEFAULT_MAX_MESSAGE_BYTES,
+        public int $maxParts = self::DEFAULT_MAX_PARTS,
+        public int $maxDepth = self::DEFAULT_MAX_DEPTH,
+        public int $maxHeaders = self::DEFAULT_MAX_HEADERS,
+        public int $maxHeaderLineLength = self::DEFAULT_MAX_HEADER_LINE_LENGTH,
+        public int $maxDecodedPartBytes = self::DEFAULT_MAX_DECODED_PART_BYTES
+    ) {
+    }
+
+    /**
+     * Create options with the package defaults.
+     *
+     * @return self
+     */
+    public static function defaults(): self
+    {
+        return new self();
+    }
+}

--- a/tests/Unit/ParserLimitsTest.php
+++ b/tests/Unit/ParserLimitsTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Tests for configurable parser safety limits.
+ *
+ * @category Tests
+ * @package  MimeMailParser
+ * @author   Ernesto Serrano <info@ernesto.es>
+ * @license  MIT https://opensource.org/licenses/MIT
+ * @link     https://github.com/erseco/mime-mail-parser
+ */
+
+namespace Tests\Unit;
+
+use Erseco\Message;
+use Erseco\ParserLimitExceededException;
+use Erseco\ParserOptions;
+
+it(
+    'parses normal messages with default limits',
+    function () {
+        $message = Message::fromString("Subject: Hello\r\nContent-Type: text/plain\r\n\r\nBody");
+
+        expect($message->getSubject())->toBe('Hello')
+            ->and($message->getTextPart()?->getContent())->toBe('Body')
+            ->and($message->getOptions()->maxParts)->toBe(ParserOptions::DEFAULT_MAX_PARTS);
+    }
+);
+
+it(
+    'allows message size exactly at the limit',
+    function () {
+        $body = 'X';
+        $raw = "Content-Type: text/plain\r\n\r\n" . $body;
+        $options = new ParserOptions(maxMessageBytes: strlen($raw));
+
+        $message = Message::fromString($raw, false, $options);
+
+        expect($message->getTextPart()?->getContent())->toBe($body);
+    }
+);
+
+it(
+    'rejects messages one byte over maxMessageBytes',
+    function () {
+        $raw = "Content-Type: text/plain\r\n\r\nBody";
+        $options = new ParserOptions(maxMessageBytes: strlen($raw) - 1);
+
+        expect(fn () => Message::fromString($raw, false, $options))
+            ->toThrow(ParserLimitExceededException::class);
+
+        try {
+            Message::fromString($raw, false, $options);
+        } catch (ParserLimitExceededException $exception) {
+            expect($exception->getLimitName())->toBe('maxMessageBytes')
+                ->and($exception->getLimitValue())->toBe(strlen($raw) - 1)
+                ->and($exception->getActualValue())->toBe(strlen($raw));
+        }
+    }
+);
+
+it(
+    'enforces maxParts globally including nested multiparts',
+    function () {
+        $raw = "Content-Type: multipart/mixed; boundary=\"b1\"\r\n\r\n"
+            . "--b1\r\nContent-Type: text/plain\r\n\r\nOne\r\n"
+            . "--b1\r\nContent-Type: multipart/alternative; boundary=\"b2\"\r\n\r\n"
+            . "--b2\r\nContent-Type: text/plain\r\n\r\nTwo\r\n"
+            . "--b2\r\nContent-Type: text/html\r\n\r\n<html>Three</html>\r\n"
+            . "--b2--\r\n"
+            . "--b1--\r\n";
+
+        $ok = new ParserOptions(maxParts: 3);
+        expect(Message::fromString($raw, false, $ok)->getParts())->toHaveCount(3);
+
+        $tooLow = new ParserOptions(maxParts: 2);
+        expect(fn () => Message::fromString($raw, false, $tooLow))
+            ->toThrow(ParserLimitExceededException::class);
+
+        try {
+            Message::fromString($raw, false, $tooLow);
+        } catch (ParserLimitExceededException $exception) {
+            expect($exception->getLimitName())->toBe('maxParts');
+        }
+    }
+);
+
+it(
+    'enforces multipart nesting depth',
+    function () {
+        $raw = "Content-Type: multipart/mixed; boundary=\"b1\"\r\n\r\n"
+            . "--b1\r\nContent-Type: multipart/mixed; boundary=\"b2\"\r\n\r\n"
+            . "--b2\r\nContent-Type: text/plain\r\n\r\nDeep\r\n"
+            . "--b2--\r\n"
+            . "--b1--\r\n";
+
+        $ok = new ParserOptions(maxDepth: 1);
+        expect(Message::fromString($raw, false, $ok)->getTextPart()?->getContent())->toBe('Deep');
+
+        $tooLow = new ParserOptions(maxDepth: 0);
+        expect(fn () => Message::fromString($raw, false, $tooLow))
+            ->toThrow(ParserLimitExceededException::class);
+
+        try {
+            Message::fromString($raw, false, $tooLow);
+        } catch (ParserLimitExceededException $exception) {
+            expect($exception->getLimitName())->toBe('maxDepth');
+        }
+    }
+);
+
+it(
+    'enforces maximum headers per header block',
+    function () {
+        $raw = "H1: a\r\nH2: b\r\nH3: c\r\nContent-Type: text/plain\r\n\r\nBody";
+        $options = new ParserOptions(maxHeaders: 3);
+
+        expect(fn () => Message::fromString($raw, false, $options))
+            ->toThrow(ParserLimitExceededException::class);
+
+        try {
+            Message::fromString($raw, false, $options);
+        } catch (ParserLimitExceededException $exception) {
+            expect($exception->getLimitName())->toBe('maxHeaders');
+        }
+    }
+);
+
+it(
+    'enforces maximum header line length',
+    function () {
+        $long = str_repeat('A', 50);
+        $raw = "Subject: {$long}\r\nContent-Type: text/plain\r\n\r\nBody";
+        $options = new ParserOptions(maxHeaderLineLength: 40);
+
+        expect(fn () => Message::fromString($raw, false, $options))
+            ->toThrow(ParserLimitExceededException::class);
+
+        try {
+            Message::fromString($raw, false, $options);
+        } catch (ParserLimitExceededException $exception) {
+            expect($exception->getLimitName())->toBe('maxHeaderLineLength');
+        }
+    }
+);
+
+it(
+    'enforces maximum decoded part size',
+    function () {
+        $payload = str_repeat('x', 20);
+        $raw = "Content-Type: text/plain\r\n"
+            . "Content-Transfer-Encoding: base64\r\n\r\n"
+            . base64_encode($payload);
+        $options = new ParserOptions(maxDecodedPartBytes: 19);
+
+        expect(fn () => Message::fromString($raw, false, $options))
+            ->toThrow(ParserLimitExceededException::class);
+
+        try {
+            Message::fromString($raw, false, $options);
+        } catch (ParserLimitExceededException $exception) {
+            expect($exception->getLimitName())->toBe('maxDecodedPartBytes')
+                ->and($exception->getActualValue())->toBe(20);
+        }
+    }
+);
+
+it(
+    'applies limits through fromFile',
+    function () {
+        $path = sys_get_temp_dir() . '/mime-mail-parser-limit-' . uniqid('', true) . '.eml';
+        $raw = "Content-Type: text/plain\r\n\r\nBody that is long enough";
+        file_put_contents($path, $raw);
+
+        try {
+            $options = new ParserOptions(maxMessageBytes: 10);
+            expect(fn () => Message::fromFile($path, false, $options))
+                ->toThrow(ParserLimitExceededException::class);
+        } finally {
+            @unlink($path);
+        }
+    }
+);
+
+it(
+    'still parses all fixture emails with default limits',
+    function () {
+        $fixtures = glob(__DIR__ . '/../Fixtures/*.eml') ?: [];
+
+        expect($fixtures)->not->toBeEmpty();
+
+        foreach ($fixtures as $fixture) {
+            $message = Message::fromFile($fixture);
+            expect($message->getParts())->not->toBeEmpty();
+        }
+    }
+);


### PR DESCRIPTION
## Summary

- Add `ParserOptions` with documented defaults for message size, parts, depth, headers, header line length, and decoded part size.
- Throw `ParserLimitExceededException` with limit name, limit value, and actual value.
- Share part counters and depth across nested multipart parsers.
- Keep constructors and factories backwards compatible with optional options.
- Document limits in the README.

## Test plan

- [x] Boundary values, over-limit cases, nested multiparts, fromFile, all fixtures under defaults
- [x] PHP 8.0–8.5 matrix
- [x] `composer lint` and full Pest suite
