### PR TITLE
Add PHPStan static analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,13 @@ jobs:
             exit 1
           }
 
+      - name: Execute static analysis
+        run: |
+          composer analyse > phpstan.log 2>&1 || {
+            tail -n 100 phpstan.log
+            exit 1
+          }
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "test": "vendor/bin/pest",
         "test-with-warnings": "vendor/bin/pest --display-warnings",
         "lint": "phpcs --standard=phpcs.xml.dist --warning-severity=0",
-        "fix": "phpcbf --standard=phpcs.xml.dist --warning-severity=0"
+        "fix": "phpcbf --standard=phpcs.xml.dist --warning-severity=0",
+        "analyse": "phpstan analyse --memory-limit=512M"
     },
     "autoload": {
         "psr-4": {
@@ -44,6 +45,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^1.23.1 || 2.35.1 || ^3.0 || ^4.0",
+        "phpstan/phpstan": "^2.0",
         "squizlabs/php_codesniffer": "^3.13 || ^4.0"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+    level: max
+    paths:
+        - src
+    excludePaths:
+        - vendor
+    # Target the oldest supported runtime while analysis may run on newer PHP.
+    phpVersion: 80000
+    treatPhpDocTypesAsCertain: false

--- a/src/Message.php
+++ b/src/Message.php
@@ -27,8 +27,10 @@ class Message implements \JsonSerializable
 
     protected ?string $boundary = null;
 
+    /** @var array<string, string> */
     protected array $headers = [];
 
+    /** @var list<MessagePart> */
     protected array $parts = [];
 
     protected bool $ignoreSignature = false;
@@ -211,7 +213,7 @@ class Message implements \JsonSerializable
      */
     public function getContentType(): string
     {
-        return $this->getHeader('Content-Type', '');
+        return $this->getStringHeader('Content-Type');
     }
 
     /**
@@ -221,7 +223,7 @@ class Message implements \JsonSerializable
      */
     public function getId(): string
     {
-        return trim($this->getHeader('Message-ID', ''), '<>');
+        return trim($this->getStringHeader('Message-ID'), '<>');
     }
 
     /**
@@ -231,7 +233,7 @@ class Message implements \JsonSerializable
      */
     public function getSubject(): string
     {
-        return $this->getHeader('Subject', '');
+        return $this->getStringHeader('Subject');
     }
 
     /**
@@ -241,7 +243,7 @@ class Message implements \JsonSerializable
      */
     public function getFrom(): string
     {
-        return $this->getHeader('From', '');
+        return $this->getStringHeader('From');
     }
 
     /**
@@ -251,7 +253,7 @@ class Message implements \JsonSerializable
      */
     public function getTo(): string
     {
-        return $this->getHeader('To', '');
+        return $this->getStringHeader('To');
     }
 
     /**
@@ -261,7 +263,7 @@ class Message implements \JsonSerializable
      */
     public function getReplyTo(): string
     {
-        return $this->getHeader('Reply-To', '');
+        return $this->getStringHeader('Reply-To');
     }
 
     /**
@@ -293,7 +295,7 @@ class Message implements \JsonSerializable
      */
     public function getDecodedSubject(): string
     {
-        return $this->getDecodedHeader('Subject', '');
+        return $this->getDecodedStringHeader('Subject');
     }
 
     /**
@@ -303,7 +305,7 @@ class Message implements \JsonSerializable
      */
     public function getDecodedFrom(): string
     {
-        return $this->getDecodedHeader('From', '');
+        return $this->getDecodedStringHeader('From');
     }
 
     /**
@@ -313,7 +315,7 @@ class Message implements \JsonSerializable
      */
     public function getDecodedTo(): string
     {
-        return $this->getDecodedHeader('To', '');
+        return $this->getDecodedStringHeader('To');
     }
 
     /**
@@ -323,7 +325,7 @@ class Message implements \JsonSerializable
      */
     public function getDecodedReplyTo(): string
     {
-        return $this->getDecodedHeader('Reply-To', '');
+        return $this->getDecodedStringHeader('Reply-To');
     }
 
     /**
@@ -627,6 +629,34 @@ class Message implements \JsonSerializable
         if ($actualValue > $limitValue) {
             throw new ParserLimitExceededException($limitName, $limitValue, $actualValue);
         }
+    }
+
+    /**
+     * Get a header value guaranteed to be a string.
+     *
+     * @param string $header Header name.
+     *
+     * @return string Header value or an empty string.
+     */
+    protected function getStringHeader(string $header): string
+    {
+        $value = $this->getHeader($header, '');
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
+     * Get a decoded header value guaranteed to be a string.
+     *
+     * @param string $header Header name.
+     *
+     * @return string Decoded header value or an empty string.
+     */
+    protected function getDecodedStringHeader(string $header): string
+    {
+        $value = $this->getDecodedHeader($header, '');
+
+        return is_string($value) ? $value : '';
     }
 
     /**

--- a/src/MessagePart.php
+++ b/src/MessagePart.php
@@ -25,6 +25,7 @@ class MessagePart implements \JsonSerializable
 {
     protected string $content;
 
+    /** @var array<string, string> */
     protected array $headers;
 
     /**
@@ -46,7 +47,7 @@ class MessagePart implements \JsonSerializable
      */
     public function getContentType(): string
     {
-        return $this->getHeader('Content-Type', '');
+        return $this->getStringHeader('Content-Type');
     }
 
     /**
@@ -88,7 +89,7 @@ class MessagePart implements \JsonSerializable
      */
     public function getContent(): string
     {
-        $encoding = strtolower(trim($this->getHeader('Content-Transfer-Encoding', '')));
+        $encoding = strtolower(trim($this->getStringHeader('Content-Transfer-Encoding')));
 
         if ($encoding === 'base64') {
             $decoded = base64_decode($this->content, true);
@@ -158,6 +159,20 @@ class MessagePart implements \JsonSerializable
     }
 
     /**
+     * Get a header value guaranteed to be a string.
+     *
+     * @param string $name Header name.
+     *
+     * @return string Header value or an empty string.
+     */
+    protected function getStringHeader(string $name): string
+    {
+        $value = $this->getHeader($name, '');
+
+        return is_string($value) ? $value : '';
+    }
+
+    /**
      * Check if this part is HTML content.
      *
      * @return bool True if the content type is text/html.
@@ -195,7 +210,7 @@ class MessagePart implements \JsonSerializable
     public function isInline(): bool
     {
         return str_starts_with(
-            strtolower(ltrim($this->getHeader('Content-Disposition', ''))),
+            strtolower(ltrim($this->getStringHeader('Content-Disposition'))),
             'inline'
         );
     }
@@ -207,7 +222,7 @@ class MessagePart implements \JsonSerializable
      */
     public function isAttachment(): bool
     {
-        $disposition = strtolower(ltrim($this->getHeader('Content-Disposition', '')));
+        $disposition = strtolower(ltrim($this->getStringHeader('Content-Disposition')));
 
         if (str_starts_with($disposition, 'attachment')) {
             return true;
@@ -223,7 +238,7 @@ class MessagePart implements \JsonSerializable
      */
     public function getContentId(): string
     {
-        return trim($this->getHeader('Content-ID', ''), '<>');
+        return trim($this->getStringHeader('Content-ID'), '<>');
     }
 
     /**

--- a/src/Rfc2047.php
+++ b/src/Rfc2047.php
@@ -212,6 +212,7 @@ final class Rfc2047
      */
     private static function windows1252ToUtf8(string $bytes): string
     {
+        /** @var array<int, string> $map */
         static $map = [
             0x80 => "\xE2\x82\xAC",
             0x82 => "\xE2\x80\x9A",
@@ -253,7 +254,7 @@ final class Rfc2047
                 continue;
             }
 
-            if (isset($map[$code])) {
+            if (array_key_exists($code, $map)) {
                 $result .= $map[$code];
                 continue;
             }


### PR DESCRIPTION
## Summary

- Add `phpstan/phpstan` (^2.0) as a development dependency.
- Add `phpstan.neon.dist` analysing `src` at **level max** with `phpVersion: 80000`.
- Add `composer analyse` and run it in the quality CI job.
- Fix iterable property types and string header accessors so analysis passes with no ignores/baseline.
- Tests are not analysed yet: Pest's dynamic expectation API produces noisy false positives without dedicated plugin support.

## Test plan

- [x] `composer analyse` (level max, no errors)
- [x] `composer lint` and `composer test`
- [x] Quality job on PHP 8.5 includes static analysis
